### PR TITLE
chore: release v0.2.2

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,0 +1,14 @@
+# Changelog
+
+All notable changes to this project will be documented in this file.
+
+The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
+and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
+
+## [Unreleased]
+
+## [0.2.2](https://github.com/secana/archive/compare/v0.2.1...v0.2.2) - 2025-12-28
+
+### Other
+
+- Add release-plz

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -19,7 +19,7 @@ dependencies = [
 
 [[package]]
 name = "archive"
-version = "0.2.1"
+version = "0.2.2"
 dependencies = [
  "bzip2",
  "flate2",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "archive"
-version = "0.2.1"
+version = "0.2.2"
 edition = "2024"
 authors = ["secana"]
 license = "MIT OR Apache-2.0"


### PR DESCRIPTION



## 🤖 New release

* `archive`: 0.2.1 -> 0.2.2 (✓ API compatible changes)

<details><summary><i><b>Changelog</b></i></summary><p>

<blockquote>

## [0.2.2](https://github.com/secana/archive/compare/v0.2.1...v0.2.2) - 2025-12-28

### Other

- Add release-plz
</blockquote>


</p></details>

---
This PR was generated with [release-plz](https://github.com/release-plz/release-plz/).