### PR TITLE
chore: release v0.3.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,0 +1,18 @@
+# Changelog
+
+All notable changes to this project will be documented in this file.
+
+The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
+and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
+
+## [Unreleased]
+
+## [0.3.0](https://github.com/secana/archive/compare/v0.2.1...v0.3.0) - 2025-12-28
+
+### Other
+
+- Cleanup old artifacts
+- Add unix archive (`.ar`) and Debian package (`.deb`) support ([#3](https://github.com/secana/archive/pull/3))
+- Bump actions/checkout from 4 to 6 ([#6](https://github.com/secana/archive/pull/6))
+- Bump actions/checkout from 4 to 6
+- Add release-plz

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -25,7 +25,7 @@ dependencies = [
 
 [[package]]
 name = "archive"
-version = "0.2.1"
+version = "0.3.0"
 dependencies = [
  "ar",
  "bzip2",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "archive"
-version = "0.2.1"
+version = "0.3.0"
 edition = "2024"
 authors = ["secana"]
 license = "MIT OR Apache-2.0"


### PR DESCRIPTION



## 🤖 New release

* `archive`: 0.2.1 -> 0.3.0 (⚠ API breaking changes)

### ⚠ `archive` breaking changes

```text
--- failure enum_no_repr_variant_discriminant_changed: enum variant had its discriminant change value ---

Description:
The enum's variant had its discriminant value change. This breaks downstream code that used its value via a numeric cast like `as isize`.
        ref: https://doc.rust-lang.org/reference/items/enumerations.html#assigning-discriminant-values
       impl: https://github.com/obi1kenobi/cargo-semver-checks/tree/v0.45.0/src/lints/enum_no_repr_variant_discriminant_changed.ron

Failed in:
  variant ArchiveFormat::TarGz 2 -> 4 in /tmp/.tmpDDGhlZ/archive/src/format.rs:73
  variant ArchiveFormat::TarBz2 3 -> 5 in /tmp/.tmpDDGhlZ/archive/src/format.rs:79
  variant ArchiveFormat::TarXz 4 -> 6 in /tmp/.tmpDDGhlZ/archive/src/format.rs:85
  variant ArchiveFormat::TarZst 5 -> 7 in /tmp/.tmpDDGhlZ/archive/src/format.rs:91
  variant ArchiveFormat::TarLz4 6 -> 8 in /tmp/.tmpDDGhlZ/archive/src/format.rs:97
  variant ArchiveFormat::Gz 7 -> 9 in /tmp/.tmpDDGhlZ/archive/src/format.rs:104
  variant ArchiveFormat::Bz2 8 -> 10 in /tmp/.tmpDDGhlZ/archive/src/format.rs:110
  variant ArchiveFormat::Xz 9 -> 11 in /tmp/.tmpDDGhlZ/archive/src/format.rs:116
  variant ArchiveFormat::Lz4 10 -> 12 in /tmp/.tmpDDGhlZ/archive/src/format.rs:122
  variant ArchiveFormat::Zst 11 -> 13 in /tmp/.tmpDDGhlZ/archive/src/format.rs:128
  variant ArchiveFormat::SevenZ 12 -> 14 in /tmp/.tmpDDGhlZ/archive/src/format.rs:134
  variant ArchiveFormat::TarGz 2 -> 4 in /tmp/.tmpDDGhlZ/archive/src/format.rs:73
  variant ArchiveFormat::TarBz2 3 -> 5 in /tmp/.tmpDDGhlZ/archive/src/format.rs:79
  variant ArchiveFormat::TarXz 4 -> 6 in /tmp/.tmpDDGhlZ/archive/src/format.rs:85
  variant ArchiveFormat::TarZst 5 -> 7 in /tmp/.tmpDDGhlZ/archive/src/format.rs:91
  variant ArchiveFormat::TarLz4 6 -> 8 in /tmp/.tmpDDGhlZ/archive/src/format.rs:97
  variant ArchiveFormat::Gz 7 -> 9 in /tmp/.tmpDDGhlZ/archive/src/format.rs:104
  variant ArchiveFormat::Bz2 8 -> 10 in /tmp/.tmpDDGhlZ/archive/src/format.rs:110
  variant ArchiveFormat::Xz 9 -> 11 in /tmp/.tmpDDGhlZ/archive/src/format.rs:116
  variant ArchiveFormat::Lz4 10 -> 12 in /tmp/.tmpDDGhlZ/archive/src/format.rs:122
  variant ArchiveFormat::Zst 11 -> 13 in /tmp/.tmpDDGhlZ/archive/src/format.rs:128
  variant ArchiveFormat::SevenZ 12 -> 14 in /tmp/.tmpDDGhlZ/archive/src/format.rs:134

--- failure enum_variant_added: enum variant added on exhaustive enum ---

Description:
A publicly-visible enum without #[non_exhaustive] has a new variant.
        ref: https://doc.rust-lang.org/cargo/reference/semver.html#enum-variant-new
       impl: https://github.com/obi1kenobi/cargo-semver-checks/tree/v0.45.0/src/lints/enum_variant_added.ron

Failed in:
  variant ArchiveFormat:Ar in /tmp/.tmpDDGhlZ/archive/src/format.rs:60
  variant ArchiveFormat:Deb in /tmp/.tmpDDGhlZ/archive/src/format.rs:67
  variant ArchiveFormat:Ar in /tmp/.tmpDDGhlZ/archive/src/format.rs:60
  variant ArchiveFormat:Deb in /tmp/.tmpDDGhlZ/archive/src/format.rs:67
```

<details><summary><i><b>Changelog</b></i></summary><p>

<blockquote>

## [0.3.0](https://github.com/secana/archive/compare/v0.2.1...v0.3.0) - 2025-12-28

### Other

- Cleanup old artifacts
- Add unix archive (`.ar`) and Debian package (`.deb`) support ([#3](https://github.com/secana/archive/pull/3))
- Bump actions/checkout from 4 to 6 ([#6](https://github.com/secana/archive/pull/6))
- Bump actions/checkout from 4 to 6
- Add release-plz
</blockquote>


</p></details>

---
This PR was generated with [release-plz](https://github.com/release-plz/release-plz/).