### PR TITLE
chore: release v0.3.2

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,12 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [0.3.2](https://github.com/secana/archive/compare/v0.3.1...v0.3.2) - 2026-06-14
+
+### Other
+
+- auto-approve and auto-merge Dependabot PRs
+
 ## [0.3.1](https://github.com/secana/archive/compare/v0.3.0...v0.3.1) - 2026-04-25
 
 ### Other

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -16,7 +16,7 @@ checksum = "d67af77d68a931ecd5cbd8a3b5987d63a1d1d1278f7f6a60ae33db485cdebb69"
 
 [[package]]
 name = "archive"
-version = "0.3.1"
+version = "0.3.2"
 dependencies = [
  "ar",
  "bzip2",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "archive"
-version = "0.3.1"
+version = "0.3.2"
 edition = "2024"
 authors = ["secana"]
 license = "MIT OR Apache-2.0"


### PR DESCRIPTION



## 🤖 New release

* `archive`: 0.3.1 -> 0.3.2 (✓ API compatible changes)

<details><summary><i><b>Changelog</b></i></summary><p>

<blockquote>

## [0.3.2](https://github.com/secana/archive/compare/v0.3.1...v0.3.2) - 2026-06-14

### Other

- auto-approve and auto-merge Dependabot PRs
</blockquote>


</p></details>

---
This PR was generated with [release-plz](https://github.com/release-plz/release-plz/).