### PR TITLE
Implement path/symlink traversal safety, convert ExtractedFile into ArchiveEntry enum for better pattern matching, protect against decompression bombs

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -16,7 +16,7 @@ checksum = "d67af77d68a931ecd5cbd8a3b5987d63a1d1d1278f7f6a60ae33db485cdebb69"
 
 [[package]]
 name = "archive"
-version = "0.3.2"
+version = "0.4.0"
 dependencies = [
  "ar",
  "bzip2",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -20,6 +20,7 @@ version = "0.4.0"
 dependencies = [
  "ar",
  "bzip2",
+ "crc32fast",
  "flate2",
  "lz4",
  "lzma-rs",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -22,3 +22,6 @@ sevenz-rust = "0.6"
 thiserror = "2.0"
 mime-type = "0.2"
 ar = "0.9.0"
+
+[dev-dependencies]
+crc32fast = "1.4"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "archive"
-version = "0.3.2"
+version = "0.4.0"
 edition = "2024"
 authors = ["secana"]
 license = "MIT OR Apache-2.0"

--- a/src/error.rs
+++ b/src/error.rs
@@ -125,6 +125,28 @@ pub enum ArchiveError {
     #[error("Unsupported format: {0}")]
     UnsupportedFormat(String),
 
+    /// Failed to allocate a buffer for an archive entry's contents.
+    ///
+    /// This is distinct from [`ArchiveError::FileTooLarge`]: it means the
+    /// entry's declared size was within the configured limit, but the
+    /// allocator couldn't actually satisfy a reservation of that size right
+    /// now (e.g. the process is low on available memory). Buffers for
+    /// entries with a known declared size are reserved up front via
+    /// `Vec::try_reserve_exact` specifically so this can be caught as a
+    /// normal error instead of aborting the process.
+    ///
+    /// # Fields
+    ///
+    /// - `size`: The number of bytes that failed to be reserved
+    #[error("Failed to allocate {size} bytes for archive entry: {source}")]
+    AllocationFailed {
+        /// The number of bytes that failed to be reserved
+        size: usize,
+        /// The underlying allocation error
+        #[source]
+        source: std::collections::TryReserveError,
+    },
+
     /// An entry's path (or, for symlinks, its target) is unsafe to extract.
     ///
     /// This is a safety feature to prevent path traversal and symlink

--- a/src/error.rs
+++ b/src/error.rs
@@ -124,4 +124,18 @@ pub enum ArchiveError {
     /// The string contains details about what is unsupported.
     #[error("Unsupported format: {0}")]
     UnsupportedFormat(String),
+
+    /// An entry's path (or, for symlinks, its target) is unsafe to extract.
+    ///
+    /// This is a safety feature to prevent path traversal and symlink
+    /// attacks. It is returned when an archive entry's path is absolute,
+    /// contains a `..` component, or (for symlink entries) points outside
+    /// the archive via such a path. Extraction is aborted rather than
+    /// silently skipping the offending entry, since a malicious archive
+    /// could otherwise smuggle unsafe entries past a caller that only
+    /// checks the return value.
+    ///
+    /// The string contains the offending path.
+    #[error("Unsafe archive entry path: {0}")]
+    UnsafePath(String),
 }

--- a/src/extractor.rs
+++ b/src/extractor.rs
@@ -7,12 +7,88 @@
 use crate::error::{ArchiveError, Result};
 use crate::format::ArchiveFormat;
 use crate::path_safety::validate_path;
-use std::io::{Cursor, Read};
+use std::io::{Cursor, Read, Write};
 
 /// Unix mode bits identifying a symbolic link (`S_IFLNK`), as stored in the
 /// upper 16 bits of a ZIP entry's `unix_mode()`.
 const S_IFLNK: u32 = 0o120000;
 const S_IFMT: u32 = 0o170000;
+
+/// Extra slack (bytes) added to `max_total_size` when bounding the raw
+/// decompressed `.tar.xz` byte stream. `lzma-rs` only exposes a one-shot,
+/// fully-buffered decompress call, so this bounds the *tar container*
+/// (data + 512-byte block headers/padding) before it's parsed into
+/// per-entry sizes; the allowance covers header overhead on archives with
+/// many small files. Individual entries are still checked precisely
+/// afterwards in [`ArchiveExtractor::process_tar_entries`].
+const TAR_XZ_HEADER_OVERHEAD_ALLOWANCE: usize = 64 * 1024 * 1024;
+
+/// A `Write` sink that stops accepting bytes once more than `limit` have
+/// been written, so a one-shot streaming decompressor (like `lzma-rs`'s
+/// `xz_decompress`) can be interrupted before a decompression bomb finishes
+/// allocating unbounded memory, instead of only being caught by a size
+/// check *after* decompression has already completed.
+struct BoundedWriter<'a> {
+    buf: &'a mut Vec<u8>,
+    limit: usize,
+    total_seen: usize,
+}
+
+impl<'a> BoundedWriter<'a> {
+    fn new(buf: &'a mut Vec<u8>, limit: usize) -> Self {
+        Self {
+            buf,
+            limit,
+            total_seen: 0,
+        }
+    }
+}
+
+/// Reserves exactly `size` bytes of capacity in `buf` up front, so a
+/// declared-size entry that's within the configured limit but too large for
+/// the allocator to actually provide right now surfaces as
+/// [`ArchiveError::AllocationFailed`] instead of aborting the process.
+fn reserve_exact(buf: &mut Vec<u8>, size: usize) -> Result<()> {
+    buf.try_reserve_exact(size)
+        .map_err(|source| ArchiveError::AllocationFailed { size, source })
+}
+
+/// Reads all of `reader` into `buf`, aborting with
+/// [`ArchiveError::FileTooLarge`] as soon as more than `limit` bytes have
+/// been produced, instead of letting a decompression bomb fully materialize
+/// in memory before the size is checked.
+fn bounded_read_to_end(reader: &mut (impl Read + ?Sized), buf: &mut Vec<u8>, limit: usize) -> Result<()> {
+    let mut writer = BoundedWriter::new(buf, limit);
+    let result = std::io::copy(reader, &mut writer);
+    let total_seen = writer.total_seen;
+    result.map(|_| ()).map_err(|e| {
+        if total_seen > limit {
+            ArchiveError::FileTooLarge {
+                size: total_seen,
+                limit,
+            }
+        } else {
+            ArchiveError::Io(e)
+        }
+    })
+}
+
+impl Write for BoundedWriter<'_> {
+    fn write(&mut self, data: &[u8]) -> std::io::Result<usize> {
+        self.total_seen += data.len();
+        if self.total_seen > self.limit {
+            return Err(std::io::Error::other(
+                "decompressed size exceeds configured limit",
+            ));
+        }
+        self.buf.extend_from_slice(data);
+        Ok(data.len())
+    }
+
+    fn flush(&mut self) -> std::io::Result<()> {
+        Ok(())
+    }
+}
 
 /// A single entry extracted from an archive.
 ///
@@ -414,6 +490,12 @@ impl ArchiveExtractor {
                 .is_some_and(|mode| mode & S_IFMT == S_IFLNK);
 
             if !is_directory {
+                // The declared size is untrusted archive metadata: reject
+                // an obviously-too-large claim up front without bothering
+                // to decompress, but don't treat a small claim as proof
+                // the entry actually is small — `bounded_read_to_end`
+                // enforces the real limit against the actual bytes
+                // produced below, regardless of what's declared here.
                 let size = file.size() as usize;
                 if size > self.max_file_size {
                     return Err(ArchiveError::FileTooLarge {
@@ -422,16 +504,17 @@ impl ArchiveExtractor {
                     });
                 }
 
-                total_size += size;
+                let mut contents = Vec::new();
+                reserve_exact(&mut contents, size)?;
+                bounded_read_to_end(&mut file, &mut contents, self.max_file_size)?;
+
+                total_size += contents.len();
                 if total_size > self.max_total_size {
                     return Err(ArchiveError::TotalSizeTooLarge {
                         size: total_size,
                         limit: self.max_total_size,
                     });
                 }
-
-                let mut contents = Vec::new();
-                file.read_to_end(&mut contents)?;
 
                 if is_symlink {
                     let target = String::from_utf8_lossy(&contents).into_owned();
@@ -484,10 +567,28 @@ impl ArchiveExtractor {
     }
 
     fn extract_tar_xz(&self, data: &[u8]) -> Result<Vec<ArchiveEntry>> {
-        let cursor = Cursor::new(data);
+        let mut cursor = Cursor::new(data);
+        let limit = self
+            .max_total_size
+            .saturating_add(TAR_XZ_HEADER_OVERHEAD_ALLOWANCE);
+
         let mut output = Vec::new();
-        lzma_rs::xz_decompress(&mut cursor.clone(), &mut output)
-            .map_err(|e| ArchiveError::InvalidArchive(e.to_string()))?;
+        let (result, total_seen) = {
+            let mut writer = BoundedWriter::new(&mut output, limit);
+            let result = lzma_rs::xz_decompress(&mut cursor, &mut writer);
+            (result, writer.total_seen)
+        };
+        result.map_err(|e| {
+            if total_seen > limit {
+                ArchiveError::TotalSizeTooLarge {
+                    size: total_seen,
+                    limit,
+                }
+            } else {
+                ArchiveError::InvalidArchive(e.to_string())
+            }
+        })?;
+
         let cursor = Cursor::new(output);
         let mut archive = tar::Archive::new(cursor);
         self.process_tar_entries(&mut archive)
@@ -529,6 +630,10 @@ impl ArchiveExtractor {
             if entry.is_directory() {
                 files.push(ArchiveEntry::Directory { path });
             } else {
+                // See the comment in extract_zip: the declared size is
+                // untrusted metadata, so it's only used to fast-reject an
+                // obviously-too-large claim here. The actual read below is
+                // bounded independently of what's declared.
                 let size = entry.size() as usize;
                 if size > self.max_file_size {
                     early_error = Some(ArchiveError::FileTooLarge {
@@ -538,7 +643,17 @@ impl ArchiveExtractor {
                     return Ok(false); // Stop iteration
                 }
 
-                total_size += size;
+                let mut contents = Vec::new();
+                if let Err(e) = reserve_exact(&mut contents, size) {
+                    early_error = Some(e);
+                    return Ok(false); // Stop iteration
+                }
+                if let Err(e) = bounded_read_to_end(reader, &mut contents, self.max_file_size) {
+                    early_error = Some(e);
+                    return Ok(false); // Stop iteration
+                }
+
+                total_size += contents.len();
                 if total_size > self.max_total_size {
                     early_error = Some(ArchiveError::TotalSizeTooLarge {
                         size: total_size,
@@ -546,9 +661,6 @@ impl ArchiveExtractor {
                     });
                     return Ok(false); // Stop iteration
                 }
-
-                let mut contents = Vec::new();
-                reader.read_to_end(&mut contents)?;
 
                 files.push(ArchiveEntry::File {
                     path,
@@ -575,14 +687,7 @@ impl ArchiveExtractor {
         let cursor = Cursor::new(data);
         let mut decoder = flate2::read::GzDecoder::new(cursor);
         let mut decompressed = Vec::new();
-        decoder.read_to_end(&mut decompressed)?;
-
-        if decompressed.len() > self.max_file_size {
-            return Err(ArchiveError::FileTooLarge {
-                size: decompressed.len(),
-                limit: self.max_file_size,
-            });
-        }
+        bounded_read_to_end(&mut decoder, &mut decompressed, self.max_file_size)?;
 
         // Try to extract original filename from gzip header. Fall back to
         // "data" if it's missing, not valid UTF-8, or unsafe (a gzip header
@@ -605,14 +710,7 @@ impl ArchiveExtractor {
         let cursor = Cursor::new(data);
         let mut decoder = bzip2::read::BzDecoder::new(cursor);
         let mut decompressed = Vec::new();
-        decoder.read_to_end(&mut decompressed)?;
-
-        if decompressed.len() > self.max_file_size {
-            return Err(ArchiveError::FileTooLarge {
-                size: decompressed.len(),
-                limit: self.max_file_size,
-            });
-        }
+        bounded_read_to_end(&mut decoder, &mut decompressed, self.max_file_size)?;
 
         Ok(vec![ArchiveEntry::File {
             path: "data".to_string(),
@@ -623,15 +721,21 @@ impl ArchiveExtractor {
     fn extract_single_xz(&self, data: &[u8]) -> Result<Vec<ArchiveEntry>> {
         let mut cursor = Cursor::new(data);
         let mut decompressed = Vec::new();
-        lzma_rs::xz_decompress(&mut cursor, &mut decompressed)
-            .map_err(|e| ArchiveError::InvalidArchive(e.to_string()))?;
-
-        if decompressed.len() > self.max_file_size {
-            return Err(ArchiveError::FileTooLarge {
-                size: decompressed.len(),
-                limit: self.max_file_size,
-            });
-        }
+        let (result, total_seen) = {
+            let mut writer = BoundedWriter::new(&mut decompressed, self.max_file_size);
+            let result = lzma_rs::xz_decompress(&mut cursor, &mut writer);
+            (result, writer.total_seen)
+        };
+        result.map_err(|e| {
+            if total_seen > self.max_file_size {
+                ArchiveError::FileTooLarge {
+                    size: total_seen,
+                    limit: self.max_file_size,
+                }
+            } else {
+                ArchiveError::InvalidArchive(e.to_string())
+            }
+        })?;
 
         Ok(vec![ArchiveEntry::File {
             path: "data".to_string(),
@@ -643,14 +747,7 @@ impl ArchiveExtractor {
         let cursor = Cursor::new(data);
         let mut decoder = lz4::Decoder::new(cursor)?;
         let mut decompressed = Vec::new();
-        decoder.read_to_end(&mut decompressed)?;
-
-        if decompressed.len() > self.max_file_size {
-            return Err(ArchiveError::FileTooLarge {
-                size: decompressed.len(),
-                limit: self.max_file_size,
-            });
-        }
+        bounded_read_to_end(&mut decoder, &mut decompressed, self.max_file_size)?;
 
         Ok(vec![ArchiveEntry::File {
             path: "data".to_string(),
@@ -662,14 +759,7 @@ impl ArchiveExtractor {
         let cursor = Cursor::new(data);
         let mut decoder = zstd::stream::read::Decoder::new(cursor)?;
         let mut decompressed = Vec::new();
-        decoder.read_to_end(&mut decompressed)?;
-
-        if decompressed.len() > self.max_file_size {
-            return Err(ArchiveError::FileTooLarge {
-                size: decompressed.len(),
-                limit: self.max_file_size,
-            });
-        }
+        bounded_read_to_end(&mut decoder, &mut decompressed, self.max_file_size)?;
 
         Ok(vec![ArchiveEntry::File {
             path: "data".to_string(),
@@ -702,6 +792,10 @@ impl ArchiveExtractor {
 
                 files.push(ArchiveEntry::Symlink { path, target });
             } else if !is_directory {
+                // See the comment in extract_zip: the declared size is
+                // untrusted metadata, so it's only used to fast-reject an
+                // obviously-too-large claim here. The actual read below is
+                // bounded independently of what's declared.
                 let size = entry.size() as usize;
                 if size > self.max_file_size {
                     return Err(ArchiveError::FileTooLarge {
@@ -710,16 +804,17 @@ impl ArchiveExtractor {
                     });
                 }
 
-                total_size += size;
+                let mut contents = Vec::new();
+                reserve_exact(&mut contents, size)?;
+                bounded_read_to_end(&mut entry, &mut contents, self.max_file_size)?;
+
+                total_size += contents.len();
                 if total_size > self.max_total_size {
                     return Err(ArchiveError::TotalSizeTooLarge {
                         size: total_size,
                         limit: self.max_total_size,
                     });
                 }
-
-                let mut contents = Vec::new();
-                entry.read_to_end(&mut contents)?;
 
                 files.push(ArchiveEntry::File {
                     path,
@@ -745,6 +840,10 @@ impl ArchiveExtractor {
             let path = String::from_utf8_lossy(entry.header().identifier()).to_string();
             validate_path(&path)?;
 
+            // See the comment in extract_zip: the declared size is
+            // untrusted metadata, so it's only used to fast-reject an
+            // obviously-too-large claim here. The actual read below is
+            // bounded independently of what's declared.
             let size = entry.header().size() as usize;
             if size > self.max_file_size {
                 return Err(ArchiveError::FileTooLarge {
@@ -753,16 +852,17 @@ impl ArchiveExtractor {
                 });
             }
 
-            total_size += size;
+            let mut contents = Vec::new();
+            reserve_exact(&mut contents, size)?;
+            bounded_read_to_end(&mut entry, &mut contents, self.max_file_size)?;
+
+            total_size += contents.len();
             if total_size > self.max_total_size {
                 return Err(ArchiveError::TotalSizeTooLarge {
                     size: total_size,
                     limit: self.max_total_size,
                 });
             }
-
-            let mut contents = Vec::new();
-            entry.read_to_end(&mut contents)?;
 
             files.push(ArchiveEntry::File { path, data: contents });
         }

--- a/src/extractor.rs
+++ b/src/extractor.rs
@@ -6,54 +6,120 @@
 
 use crate::error::{ArchiveError, Result};
 use crate::format::ArchiveFormat;
+use crate::path_safety::validate_path;
 use std::io::{Cursor, Read};
 
-/// Represents a single file extracted from an archive.
+/// Unix mode bits identifying a symbolic link (`S_IFLNK`), as stored in the
+/// upper 16 bits of a ZIP entry's `unix_mode()`.
+const S_IFLNK: u32 = 0o120000;
+const S_IFMT: u32 = 0o170000;
+
+/// A single entry extracted from an archive.
 ///
-/// This structure contains the file's path within the archive, its contents,
-/// and metadata about whether it represents a directory.
+/// Each variant carries only the fields that make sense for that kind of
+/// entry, so states like "directory with file contents" or "symlink with no
+/// target" can't be represented.
 ///
 /// # Examples
 ///
 /// ```no_run
-/// use archive::{ArchiveExtractor, ArchiveFormat};
+/// use archive::{ArchiveEntry, ArchiveExtractor, ArchiveFormat};
 ///
 /// # fn main() -> Result<(), Box<dyn std::error::Error>> {
 /// let extractor = ArchiveExtractor::new();
 /// # let data = vec![0u8; 100];
-/// let files = extractor.extract(&data, ArchiveFormat::Zip)?;
+/// let entries = extractor.extract(&data, ArchiveFormat::Zip)?;
 ///
-/// for file in files {
-///     if file.is_directory {
-///         println!("Directory: {}", file.path);
-///     } else {
-///         println!("File: {} ({} bytes)", file.path, file.data.len());
-///         // Process file.data as needed
+/// for entry in &entries {
+///     match entry {
+///         ArchiveEntry::File { path, data } => {
+///             println!("File: {} ({} bytes)", path, data.len());
+///         }
+///         ArchiveEntry::Directory { path } => {
+///             println!("Directory: {}", path);
+///         }
+///         ArchiveEntry::Symlink { path, target } => {
+///             println!("Symlink: {} -> {}", path, target);
+///         }
 ///     }
 /// }
 /// # Ok(())
 /// # }
 /// ```
 #[derive(Debug, Clone)]
-pub struct ExtractedFile {
-    /// The original path of the file within the archive.
-    ///
-    /// For multi-file archives (ZIP, TAR, 7-Zip), this is the path as stored
-    /// in the archive. For single-file compression formats:
-    /// - **Gzip**: The original filename from the header, or "data" if not present
-    /// - **Bzip2, XZ, LZ4, Zstandard**: Always "data" as these formats don't store filenames
-    pub path: String,
+pub enum ArchiveEntry {
+    /// A regular file with decompressed contents.
+    File {
+        /// The path of the file within the archive.
+        ///
+        /// For multi-file archives (ZIP, TAR, 7-Zip), this is the path as
+        /// stored in the archive. For single-file compression formats:
+        /// - **Gzip**: The original filename from the header, or "data" if not present
+        /// - **Bzip2, XZ, LZ4, Zstandard**: Always "data" as these formats don't store filenames
+        path: String,
+        /// The decompressed contents of the file.
+        data: Vec<u8>,
+    },
 
-    /// The decompressed contents of the file.
-    ///
-    /// For directories, this will be an empty vector.
-    pub data: Vec<u8>,
+    /// A directory entry.
+    Directory {
+        /// The path of the directory within the archive.
+        path: String,
+    },
 
-    /// Whether this entry represents a directory.
+    /// A symbolic (or hard) link entry.
     ///
-    /// If `true`, the `data` field will be empty and `path` represents a directory.
-    /// If `false`, this is a regular file with content in `data`.
-    pub is_directory: bool,
+    /// The target has already been validated to not contain a `..`
+    /// component or be absolute — extraction fails with
+    /// [`ArchiveError::UnsafePath`] before this variant is ever produced for
+    /// an unsafe target.
+    ///
+    /// Callers that materialize entries onto a filesystem should treat
+    /// symlink entries with extra care: creating a symlink and then writing
+    /// through a later entry that happens to resolve through it is a classic
+    /// archive extraction attack, so most callers should either skip
+    /// symlink entries entirely or re-validate the target against their own
+    /// extraction root before creating the link.
+    Symlink {
+        /// The path of the symlink within the archive.
+        path: String,
+        /// The link target, as recorded in the archive.
+        target: String,
+    },
+}
+
+impl ArchiveEntry {
+    /// Returns the path of this entry within the archive.
+    pub fn path(&self) -> &str {
+        match self {
+            ArchiveEntry::File { path, .. } => path,
+            ArchiveEntry::Directory { path } => path,
+            ArchiveEntry::Symlink { path, .. } => path,
+        }
+    }
+
+    /// Returns `true` if this entry is a regular file.
+    pub fn is_file(&self) -> bool {
+        matches!(self, ArchiveEntry::File { .. })
+    }
+
+    /// Returns `true` if this entry is a directory.
+    pub fn is_directory(&self) -> bool {
+        matches!(self, ArchiveEntry::Directory { .. })
+    }
+
+    /// Returns `true` if this entry is a symlink.
+    pub fn is_symlink(&self) -> bool {
+        matches!(self, ArchiveEntry::Symlink { .. })
+    }
+
+    /// Returns the file contents, or `None` if this entry isn't a [`ArchiveEntry::File`].
+    pub fn data(&self) -> Option<&[u8]> {
+        match self {
+            ArchiveEntry::File { data, .. } => Some(data),
+            _ => None,
+        }
+    }
 }
 
 /// Main extractor that handles all archive formats.
@@ -234,8 +300,8 @@ impl ArchiveExtractor {
     ///
     /// # Returns
     ///
-    /// Returns a `Vec<ExtractedFile>` containing all files and directories from the archive.
-    /// Directories will have `is_directory` set to `true` and an empty `data` field.
+    /// Returns a `Vec<ArchiveEntry>` containing all files, directories, and symlinks
+    /// from the archive.
     ///
     /// # Errors
     ///
@@ -259,8 +325,8 @@ impl ArchiveExtractor {
     /// let extractor = ArchiveExtractor::new();
     /// let files = extractor.extract(&data, ArchiveFormat::Zip)?;
     ///
-    /// for file in files {
-    ///     println!("{}: {} bytes", file.path, file.data.len());
+    /// for entry in &files {
+    ///     println!("{}: {} bytes", entry.path(), entry.data().map_or(0, <[u8]>::len));
     /// }
     /// # Ok(())
     /// # }
@@ -311,7 +377,7 @@ impl ArchiveExtractor {
     /// # Ok(())
     /// # }
     /// ```
-    pub fn extract(&self, data: &[u8], format: ArchiveFormat) -> Result<Vec<ExtractedFile>> {
+    pub fn extract(&self, data: &[u8], format: ArchiveFormat) -> Result<Vec<ArchiveEntry>> {
         match format {
             ArchiveFormat::Zip => self.extract_zip(data),
             ArchiveFormat::Tar => self.extract_tar(data),
@@ -331,7 +397,7 @@ impl ArchiveExtractor {
         }
     }
 
-    fn extract_zip(&self, data: &[u8]) -> Result<Vec<ExtractedFile>> {
+    fn extract_zip(&self, data: &[u8]) -> Result<Vec<ArchiveEntry>> {
         let reader = Cursor::new(data);
         let mut archive = zip::ZipArchive::new(reader)?;
         let mut files = Vec::new();
@@ -340,6 +406,12 @@ impl ArchiveExtractor {
         for i in 0..archive.len() {
             let mut file = archive.by_index(i)?;
             let is_directory = file.is_dir();
+            let path = file.name().to_string();
+            validate_path(&path)?;
+
+            let is_symlink = file
+                .unix_mode()
+                .is_some_and(|mode| mode & S_IFMT == S_IFLNK);
 
             if !is_directory {
                 let size = file.size() as usize;
@@ -361,56 +433,57 @@ impl ArchiveExtractor {
                 let mut contents = Vec::new();
                 file.read_to_end(&mut contents)?;
 
-                files.push(ExtractedFile {
-                    path: file.name().to_string(),
-                    data: contents,
-                    is_directory,
-                });
+                if is_symlink {
+                    let target = String::from_utf8_lossy(&contents).into_owned();
+                    validate_path(&target)?;
+                    files.push(ArchiveEntry::Symlink { path, target });
+                } else {
+                    files.push(ArchiveEntry::File {
+                        path,
+                        data: contents,
+                    });
+                }
             } else {
-                files.push(ExtractedFile {
-                    path: file.name().to_string(),
-                    data: Vec::new(),
-                    is_directory,
-                });
+                files.push(ArchiveEntry::Directory { path });
             }
         }
 
         Ok(files)
     }
 
-    fn extract_tar(&self, data: &[u8]) -> Result<Vec<ExtractedFile>> {
+    fn extract_tar(&self, data: &[u8]) -> Result<Vec<ArchiveEntry>> {
         let cursor = Cursor::new(data);
         let mut archive = tar::Archive::new(cursor);
         self.process_tar_entries(&mut archive)
     }
 
-    fn extract_ar(&self, data: &[u8]) -> Result<Vec<ExtractedFile>> {
+    fn extract_ar(&self, data: &[u8]) -> Result<Vec<ArchiveEntry>> {
         let cursor = Cursor::new(data);
         let mut archive = ar::Archive::new(cursor);
         self.process_ar_entries(&mut archive)
     }
 
-    fn extract_deb(&self, data: &[u8]) -> Result<Vec<ExtractedFile>> {
+    fn extract_deb(&self, data: &[u8]) -> Result<Vec<ArchiveEntry>> {
         let cursor = Cursor::new(data);
         let mut archive = ar::Archive::new(cursor);
         self.process_ar_entries(&mut archive)
     }
 
-    fn extract_tar_gz(&self, data: &[u8]) -> Result<Vec<ExtractedFile>> {
+    fn extract_tar_gz(&self, data: &[u8]) -> Result<Vec<ArchiveEntry>> {
         let cursor = Cursor::new(data);
         let decoder = flate2::read::GzDecoder::new(cursor);
         let mut archive = tar::Archive::new(decoder);
         self.process_tar_entries(&mut archive)
     }
 
-    fn extract_tar_bz2(&self, data: &[u8]) -> Result<Vec<ExtractedFile>> {
+    fn extract_tar_bz2(&self, data: &[u8]) -> Result<Vec<ArchiveEntry>> {
         let cursor = Cursor::new(data);
         let decoder = bzip2::read::BzDecoder::new(cursor);
         let mut archive = tar::Archive::new(decoder);
         self.process_tar_entries(&mut archive)
     }
 
-    fn extract_tar_xz(&self, data: &[u8]) -> Result<Vec<ExtractedFile>> {
+    fn extract_tar_xz(&self, data: &[u8]) -> Result<Vec<ArchiveEntry>> {
         let cursor = Cursor::new(data);
         let mut output = Vec::new();
         lzma_rs::xz_decompress(&mut cursor.clone(), &mut output)
@@ -420,21 +493,21 @@ impl ArchiveExtractor {
         self.process_tar_entries(&mut archive)
     }
 
-    fn extract_tar_zst(&self, data: &[u8]) -> Result<Vec<ExtractedFile>> {
+    fn extract_tar_zst(&self, data: &[u8]) -> Result<Vec<ArchiveEntry>> {
         let cursor = Cursor::new(data);
         let decoder = zstd::stream::read::Decoder::new(cursor)?;
         let mut archive = tar::Archive::new(decoder);
         self.process_tar_entries(&mut archive)
     }
 
-    fn extract_tar_lz4(&self, data: &[u8]) -> Result<Vec<ExtractedFile>> {
+    fn extract_tar_lz4(&self, data: &[u8]) -> Result<Vec<ArchiveEntry>> {
         let cursor = Cursor::new(data);
         let decoder = lz4::Decoder::new(cursor)?;
         let mut archive = tar::Archive::new(decoder);
         self.process_tar_entries(&mut archive)
     }
 
-    fn extract_7z(&self, data: &[u8]) -> Result<Vec<ExtractedFile>> {
+    fn extract_7z(&self, data: &[u8]) -> Result<Vec<ArchiveEntry>> {
         let mut cursor = Cursor::new(data);
         let len = cursor.get_ref().len() as u64;
 
@@ -443,20 +516,22 @@ impl ArchiveExtractor {
 
         let mut files = Vec::new();
         let mut total_size = 0usize;
-        let mut size_error: Option<ArchiveError> = None;
+        let mut early_error: Option<ArchiveError> = None;
 
         // Single-pass extraction: validate sizes and extract contents in one iteration
         let result = archive.for_each_entries(|entry, reader| {
+            let path = entry.name().to_string();
+            if let Err(e) = validate_path(&path) {
+                early_error = Some(e);
+                return Ok(false); // Stop iteration
+            }
+
             if entry.is_directory() {
-                files.push(ExtractedFile {
-                    path: entry.name().to_string(),
-                    data: Vec::new(),
-                    is_directory: true,
-                });
+                files.push(ArchiveEntry::Directory { path });
             } else {
                 let size = entry.size() as usize;
                 if size > self.max_file_size {
-                    size_error = Some(ArchiveError::FileTooLarge {
+                    early_error = Some(ArchiveError::FileTooLarge {
                         size,
                         limit: self.max_file_size,
                     });
@@ -465,7 +540,7 @@ impl ArchiveExtractor {
 
                 total_size += size;
                 if total_size > self.max_total_size {
-                    size_error = Some(ArchiveError::TotalSizeTooLarge {
+                    early_error = Some(ArchiveError::TotalSizeTooLarge {
                         size: total_size,
                         limit: self.max_total_size,
                     });
@@ -475,17 +550,16 @@ impl ArchiveExtractor {
                 let mut contents = Vec::new();
                 reader.read_to_end(&mut contents)?;
 
-                files.push(ExtractedFile {
-                    path: entry.name().to_string(),
+                files.push(ArchiveEntry::File {
+                    path,
                     data: contents,
-                    is_directory: false,
                 });
             }
             Ok(true)
         });
 
-        // Check if we stopped due to size limits
-        if let Some(err) = size_error {
+        // Check if we stopped due to a size or path-safety violation
+        if let Some(err) = early_error {
             return Err(err);
         }
 
@@ -497,7 +571,7 @@ impl ArchiveExtractor {
 
     // Single-file decompression methods
 
-    fn extract_single_gz(&self, data: &[u8]) -> Result<Vec<ExtractedFile>> {
+    fn extract_single_gz(&self, data: &[u8]) -> Result<Vec<ArchiveEntry>> {
         let cursor = Cursor::new(data);
         let mut decoder = flate2::read::GzDecoder::new(cursor);
         let mut decompressed = Vec::new();
@@ -510,22 +584,24 @@ impl ArchiveExtractor {
             });
         }
 
-        // Try to extract original filename from gzip header
+        // Try to extract original filename from gzip header. Fall back to
+        // "data" if it's missing, not valid UTF-8, or unsafe (a gzip header
+        // filename is attacker-controlled and could contain e.g. "../..").
         let path = decoder
             .header()
             .and_then(|h| h.filename())
             .and_then(|f| std::str::from_utf8(f).ok())
+            .filter(|f| validate_path(f).is_ok())
             .unwrap_or("data")
             .to_string();
 
-        Ok(vec![ExtractedFile {
+        Ok(vec![ArchiveEntry::File {
             path,
             data: decompressed,
-            is_directory: false,
         }])
     }
 
-    fn extract_single_bz2(&self, data: &[u8]) -> Result<Vec<ExtractedFile>> {
+    fn extract_single_bz2(&self, data: &[u8]) -> Result<Vec<ArchiveEntry>> {
         let cursor = Cursor::new(data);
         let mut decoder = bzip2::read::BzDecoder::new(cursor);
         let mut decompressed = Vec::new();
@@ -538,14 +614,13 @@ impl ArchiveExtractor {
             });
         }
 
-        Ok(vec![ExtractedFile {
+        Ok(vec![ArchiveEntry::File {
             path: "data".to_string(),
             data: decompressed,
-            is_directory: false,
         }])
     }
 
-    fn extract_single_xz(&self, data: &[u8]) -> Result<Vec<ExtractedFile>> {
+    fn extract_single_xz(&self, data: &[u8]) -> Result<Vec<ArchiveEntry>> {
         let mut cursor = Cursor::new(data);
         let mut decompressed = Vec::new();
         lzma_rs::xz_decompress(&mut cursor, &mut decompressed)
@@ -558,14 +633,13 @@ impl ArchiveExtractor {
             });
         }
 
-        Ok(vec![ExtractedFile {
+        Ok(vec![ArchiveEntry::File {
             path: "data".to_string(),
             data: decompressed,
-            is_directory: false,
         }])
     }
 
-    fn extract_single_lz4(&self, data: &[u8]) -> Result<Vec<ExtractedFile>> {
+    fn extract_single_lz4(&self, data: &[u8]) -> Result<Vec<ArchiveEntry>> {
         let cursor = Cursor::new(data);
         let mut decoder = lz4::Decoder::new(cursor)?;
         let mut decompressed = Vec::new();
@@ -578,14 +652,13 @@ impl ArchiveExtractor {
             });
         }
 
-        Ok(vec![ExtractedFile {
+        Ok(vec![ArchiveEntry::File {
             path: "data".to_string(),
             data: decompressed,
-            is_directory: false,
         }])
     }
 
-    fn extract_single_zst(&self, data: &[u8]) -> Result<Vec<ExtractedFile>> {
+    fn extract_single_zst(&self, data: &[u8]) -> Result<Vec<ArchiveEntry>> {
         let cursor = Cursor::new(data);
         let mut decoder = zstd::stream::read::Decoder::new(cursor)?;
         let mut decompressed = Vec::new();
@@ -598,26 +671,37 @@ impl ArchiveExtractor {
             });
         }
 
-        Ok(vec![ExtractedFile {
+        Ok(vec![ArchiveEntry::File {
             path: "data".to_string(),
             data: decompressed,
-            is_directory: false,
         }])
     }
 
     fn process_tar_entries<R: Read>(
         &self,
         archive: &mut tar::Archive<R>,
-    ) -> Result<Vec<ExtractedFile>> {
+    ) -> Result<Vec<ArchiveEntry>> {
         let mut files = Vec::new();
         let mut total_size = 0usize;
 
         for entry_result in archive.entries()? {
             let mut entry = entry_result?;
             let path = entry.path()?.to_string_lossy().to_string();
-            let is_directory = entry.header().entry_type().is_dir();
+            validate_path(&path)?;
 
-            if !is_directory {
+            let entry_type = entry.header().entry_type();
+            let is_directory = entry_type.is_dir();
+            let is_symlink = entry_type.is_symlink() || entry_type.is_hard_link();
+
+            if is_symlink {
+                let target = entry
+                    .link_name()?
+                    .map(|t| t.to_string_lossy().to_string())
+                    .unwrap_or_default();
+                validate_path(&target)?;
+
+                files.push(ArchiveEntry::Symlink { path, target });
+            } else if !is_directory {
                 let size = entry.size() as usize;
                 if size > self.max_file_size {
                     return Err(ArchiveError::FileTooLarge {
@@ -637,17 +721,12 @@ impl ArchiveExtractor {
                 let mut contents = Vec::new();
                 entry.read_to_end(&mut contents)?;
 
-                files.push(ExtractedFile {
+                files.push(ArchiveEntry::File {
                     path,
                     data: contents,
-                    is_directory,
                 });
             } else {
-                files.push(ExtractedFile {
-                    path,
-                    data: Vec::new(),
-                    is_directory,
-                });
+                files.push(ArchiveEntry::Directory { path });
             }
         }
 
@@ -657,13 +736,14 @@ impl ArchiveExtractor {
     fn process_ar_entries<R: Read>(
         &self,
         archive: &mut ar::Archive<R>,
-    ) -> Result<Vec<ExtractedFile>> {
+    ) -> Result<Vec<ArchiveEntry>> {
         let mut files = Vec::new();
         let mut total_size = 0usize;
 
-        while let Some(entry_result) = archive.next_entry(){
+        while let Some(entry_result) = archive.next_entry() {
             let mut entry = entry_result?;
             let path = String::from_utf8_lossy(entry.header().identifier()).to_string();
+            validate_path(&path)?;
 
             let size = entry.header().size() as usize;
             if size > self.max_file_size {
@@ -684,11 +764,7 @@ impl ArchiveExtractor {
             let mut contents = Vec::new();
             entry.read_to_end(&mut contents)?;
 
-            files.push(ExtractedFile {
-                path,
-                data: contents,
-                is_directory: false,
-            });
+            files.push(ArchiveEntry::File { path, data: contents });
         }
 
         Ok(files)

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -8,7 +8,7 @@
 //!
 //! - **Unified API**: Single interface for all archive formats
 //! - **In-memory extraction**: No disk I/O required
-//! - **Safety limits**: Protection against zip bombs and resource exhaustion
+//! - **Safety limits**: Protection against zip bombs, path traversal attacks, and resource exhaustion
 //! - **Pure Rust**: Minimal C dependencies (only bzip2)
 //! - **Cross-platform**: Works on Linux, macOS, Windows (x86_64, ARM64)
 //!
@@ -38,9 +38,9 @@
 //! let files = extractor.extract(&data, ArchiveFormat::Zip)?;
 //!
 //! // Process extracted files
-//! for file in files {
-//!     if !file.is_directory {
-//!         println!("File: {} ({} bytes)", file.path, file.data.len());
+//! for entry in &files {
+//!     if let archive::ArchiveEntry::File { path, data } = entry {
+//!         println!("File: {} ({} bytes)", path, data.len());
 //!     }
 //! }
 //! # Ok(())
@@ -126,7 +126,8 @@
 pub mod error;
 pub mod extractor;
 pub mod format;
+pub mod path_safety;
 
 pub use error::{ArchiveError, Result};
-pub use extractor::{ArchiveExtractor, ExtractedFile};
+pub use extractor::{ArchiveEntry, ArchiveExtractor};
 pub use format::ArchiveFormat;

--- a/src/path_safety.rs
+++ b/src/path_safety.rs
@@ -1,0 +1,83 @@
+//! Validation helpers that protect against path traversal and unsafe symlink
+//! targets embedded in archive entries.
+//!
+//! Archive formats let each entry declare an arbitrary path (and, for
+//! symlinks, an arbitrary target). A malicious archive can use `..`
+//! components or absolute paths to try to escape the directory a caller
+//! intends to extract into, or to point a symlink at a file outside that
+//! directory. This module centralizes the checks used by every format's
+//! extraction path so callers can trust that [`crate::ExtractedFile::path`]
+//! (and symlink targets) never contain such components.
+
+use crate::error::{ArchiveError, Result};
+
+/// Validates that an archive-supplied path (entry name or symlink target) is
+/// safe to join onto an extraction directory.
+///
+/// Rejects:
+/// - empty paths
+/// - paths containing a NUL byte
+/// - absolute paths (`/foo`, `\foo`, `C:\foo`, `C:/foo`)
+/// - paths with any `..` component
+pub fn validate_path(path: &str) -> Result<()> {
+    if path.is_empty() {
+        return Err(ArchiveError::UnsafePath(path.to_string()));
+    }
+
+    if path.contains('\0') {
+        return Err(ArchiveError::UnsafePath(path.to_string()));
+    }
+
+    if path.starts_with('/') || path.starts_with('\\') {
+        return Err(ArchiveError::UnsafePath(path.to_string()));
+    }
+
+    // Windows drive-letter absolute path, e.g. "C:\foo" or "C:/foo".
+    let bytes = path.as_bytes();
+    if bytes.len() >= 2 && bytes[0].is_ascii_alphabetic() && bytes[1] == b':' {
+        return Err(ArchiveError::UnsafePath(path.to_string()));
+    }
+
+    for component in path.split(['/', '\\']) {
+        if component == ".." {
+            return Err(ArchiveError::UnsafePath(path.to_string()));
+        }
+    }
+
+    Ok(())
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn accepts_normal_relative_paths() {
+        assert!(validate_path("foo/bar.txt").is_ok());
+        assert!(validate_path("foo.txt").is_ok());
+        assert!(validate_path("./foo/bar.txt").is_ok());
+        assert!(validate_path("a/b/c/d.txt").is_ok());
+    }
+
+    #[test]
+    fn rejects_parent_dir_components() {
+        assert!(validate_path("../etc/passwd").is_err());
+        assert!(validate_path("foo/../../etc/passwd").is_err());
+        assert!(validate_path("foo/bar/..").is_err());
+        assert!(validate_path("..\\..\\windows\\system32").is_err());
+    }
+
+    #[test]
+    fn rejects_absolute_paths() {
+        assert!(validate_path("/etc/passwd").is_err());
+        assert!(validate_path("\\Windows\\System32").is_err());
+        assert!(validate_path("C:\\Windows\\System32").is_err());
+        assert!(validate_path("C:/Windows/System32").is_err());
+    }
+
+    #[test]
+    fn rejects_empty_and_nul() {
+        assert!(validate_path("").is_err());
+        assert!(validate_path("foo\0bar").is_err());
+    }
+}

--- a/tests/common/mod.rs
+++ b/tests/common/mod.rs
@@ -1,6 +1,6 @@
 //! Common test utilities and helpers
 
-use archive::ExtractedFile;
+use archive::ArchiveEntry;
 use std::fs;
 use std::path::Path;
 
@@ -20,12 +20,12 @@ pub fn read_test_archive(filename: &str) -> Vec<u8> {
 /// Helper to check if extracted files contain expected content
 #[allow(dead_code)]
 pub fn assert_contains_file<'a>(
-    files: &'a [ExtractedFile],
+    files: &'a [ArchiveEntry],
     path_contains: &str,
-) -> &'a ExtractedFile {
+) -> &'a ArchiveEntry {
     files
         .iter()
-        .find(|f| f.path.contains(path_contains))
+        .find(|f| f.path().contains(path_contains))
         .unwrap_or_else(|| {
             panic!(
                 "Expected to find file containing '{}' in path",

--- a/tests/content_tests.rs
+++ b/tests/content_tests.rs
@@ -16,7 +16,7 @@ fn test_verify_file_contents() {
 
     // Find hello.txt and verify its content
     let hello_file = assert_contains_file(&files, "hello.txt");
-    let content = String::from_utf8_lossy(&hello_file.data);
+    let content = String::from_utf8_lossy(hello_file.data().unwrap());
 
     assert_eq!(content.trim(), "Hello, World!", "Unexpected file content");
 }
@@ -48,7 +48,7 @@ fn test_binary_file_extraction() {
 
     // Should be 10KB of random data
     assert_eq!(
-        binary_file.data.len(),
+        binary_file.data().unwrap().len(),
         10 * 1024,
         "Expected 10KB binary file"
     );
@@ -67,5 +67,5 @@ fn test_large_file_extraction() {
     let large_file = assert_contains_file(&files, "large-file.bin");
 
     // Should be 1MB of random data
-    assert_eq!(large_file.data.len(), 1024 * 1024, "Expected 1MB file");
+    assert_eq!(large_file.data().unwrap().len(), 1024 * 1024, "Expected 1MB file");
 }

--- a/tests/declared_size_bypass_tests.rs
+++ b/tests/declared_size_bypass_tests.rs
@@ -1,0 +1,102 @@
+//! Regression test for a size-limit bypass: a zip entry's declared
+//! "uncompressed size" (in its local file header / central directory) is
+//! untrusted archive metadata. Before this fix, `extract_zip` checked that
+//! declared size against `max_file_size` but then read the entry's *actual*
+//! decompressed bytes unbounded, so a small declared size with a genuinely
+//! huge compressed payload sailed straight past the configured limit.
+//!
+//! This crafts such a zip by hand (the `zip` crate's own writer always
+//! computes an honest size, so it can't be used to build the malicious
+//! case) and confirms extraction is now rejected via `FileTooLarge`.
+
+use archive::{ArchiveError, ArchiveExtractor, ArchiveFormat};
+use flate2::write::DeflateEncoder;
+use flate2::Compression;
+use std::io::Write;
+
+/// Builds a single-entry zip where the declared uncompressed size lies:
+/// it claims `declared_size` bytes, but the compressed data actually
+/// inflates to `real_data.len()` bytes.
+fn build_zip_with_lying_size(name: &str, real_data: &[u8], declared_size: u32) -> Vec<u8> {
+    let mut encoder = DeflateEncoder::new(Vec::new(), Compression::default());
+    encoder.write_all(real_data).unwrap();
+    let compressed = encoder.finish().unwrap();
+
+    let crc = crc32fast::hash(real_data);
+    let name_bytes = name.as_bytes();
+
+    let mut local_header = Vec::new();
+    local_header.extend_from_slice(&0x04034b50u32.to_le_bytes()); // local file header signature
+    local_header.extend_from_slice(&20u16.to_le_bytes()); // version needed
+    local_header.extend_from_slice(&0u16.to_le_bytes()); // flags
+    local_header.extend_from_slice(&8u16.to_le_bytes()); // method: deflate
+    local_header.extend_from_slice(&0u16.to_le_bytes()); // mod time
+    local_header.extend_from_slice(&0u16.to_le_bytes()); // mod date
+    local_header.extend_from_slice(&crc.to_le_bytes());
+    local_header.extend_from_slice(&(compressed.len() as u32).to_le_bytes()); // compressed size (honest)
+    local_header.extend_from_slice(&declared_size.to_le_bytes()); // uncompressed size (THE LIE)
+    local_header.extend_from_slice(&(name_bytes.len() as u16).to_le_bytes());
+    local_header.extend_from_slice(&0u16.to_le_bytes()); // extra field length
+    local_header.extend_from_slice(name_bytes);
+
+    let mut central_dir = Vec::new();
+    central_dir.extend_from_slice(&0x02014b50u32.to_le_bytes()); // central dir signature
+    central_dir.extend_from_slice(&20u16.to_le_bytes()); // version made by
+    central_dir.extend_from_slice(&20u16.to_le_bytes()); // version needed
+    central_dir.extend_from_slice(&0u16.to_le_bytes()); // flags
+    central_dir.extend_from_slice(&8u16.to_le_bytes()); // method: deflate
+    central_dir.extend_from_slice(&0u16.to_le_bytes()); // mod time
+    central_dir.extend_from_slice(&0u16.to_le_bytes()); // mod date
+    central_dir.extend_from_slice(&crc.to_le_bytes());
+    central_dir.extend_from_slice(&(compressed.len() as u32).to_le_bytes());
+    central_dir.extend_from_slice(&declared_size.to_le_bytes()); // THE LIE, again
+    central_dir.extend_from_slice(&(name_bytes.len() as u16).to_le_bytes());
+    central_dir.extend_from_slice(&0u16.to_le_bytes()); // extra field length
+    central_dir.extend_from_slice(&0u16.to_le_bytes()); // comment length
+    central_dir.extend_from_slice(&0u16.to_le_bytes()); // disk number
+    central_dir.extend_from_slice(&0u16.to_le_bytes()); // internal attrs
+    central_dir.extend_from_slice(&0u32.to_le_bytes()); // external attrs
+    central_dir.extend_from_slice(&0u32.to_le_bytes()); // local header offset
+    central_dir.extend_from_slice(name_bytes);
+
+    let mut eocd = Vec::new();
+    eocd.extend_from_slice(&0x06054b50u32.to_le_bytes());
+    eocd.extend_from_slice(&0u16.to_le_bytes()); // disk number
+    eocd.extend_from_slice(&0u16.to_le_bytes()); // central dir disk number
+    eocd.extend_from_slice(&1u16.to_le_bytes()); // entries on this disk
+    eocd.extend_from_slice(&1u16.to_le_bytes()); // total entries
+    eocd.extend_from_slice(&(central_dir.len() as u32).to_le_bytes());
+    eocd.extend_from_slice(&((local_header.len() + compressed.len()) as u32).to_le_bytes());
+    eocd.extend_from_slice(&0u16.to_le_bytes()); // comment length
+
+    let mut zip = Vec::new();
+    zip.extend_from_slice(&local_header);
+    zip.extend_from_slice(&compressed);
+    zip.extend_from_slice(&central_dir);
+    zip.extend_from_slice(&eocd);
+    zip
+}
+
+#[test]
+fn zip_lying_declared_size_is_rejected_via_actual_bytes_read() {
+    // 50 MB of zeros compresses to a tiny deflate stream, but the header
+    // claims the entry is only 100 bytes uncompressed.
+    let real_data = vec![0u8; 50 * 1024 * 1024];
+    let zip = build_zip_with_lying_size("lie.txt", &real_data, 100);
+
+    // Well above the lie (100 bytes), well below the real size (50MB).
+    let extractor = ArchiveExtractor::new().with_max_file_size(10 * 1024 * 1024);
+    let err = extractor.extract(&zip, ArchiveFormat::Zip).unwrap_err();
+    assert!(matches!(err, ArchiveError::FileTooLarge { .. }), "{err:?}");
+}
+
+#[test]
+fn zip_honest_declared_size_still_extracts_normally() {
+    let real_data = b"hello world".to_vec();
+    let zip = build_zip_with_lying_size("hello.txt", &real_data, real_data.len() as u32);
+
+    let extractor = ArchiveExtractor::new();
+    let files = extractor.extract(&zip, ArchiveFormat::Zip).unwrap();
+    assert_eq!(files.len(), 1);
+    assert_eq!(files[0].data(), Some(&real_data[..]));
+}

--- a/tests/decompression_bomb_tests.rs
+++ b/tests/decompression_bomb_tests.rs
@@ -1,0 +1,104 @@
+//! Regression tests: small, highly-compressible single-file archives that
+//! decompress far beyond the configured max_file_size must be rejected via
+//! ArchiveError::FileTooLarge without ever fully buffering the bomb.
+//!
+//! Bombs are generated with the real system CLI tools (200 MB of zeros
+//! compressed down to a few hundred bytes to a few hundred KB depending on
+//! the format) rather than each format's Rust encoder, since some of those
+//! encoders (e.g. `lzma_rs`) don't compress repeated data well enough to
+//! produce a realistic bomb.
+
+use archive::{ArchiveError, ArchiveExtractor, ArchiveFormat};
+use std::io::Write;
+use std::process::{Command, Stdio};
+
+/// Runs `cmd args... < 200MB of zeros`, returning the compressed stdout, or
+/// `None` if the tool isn't installed (in which case the test is skipped).
+///
+/// The 200 MB write to stdin happens on a separate thread, concurrently
+/// with reading stdout on this one: writing it all up front and only then
+/// reading stdout would deadlock once the child's compressed output
+/// exceeds the OS pipe buffer (~64 KB on Linux) before it's consumed all
+/// of its input — the child blocks writing output while we're still
+/// blocked writing input.
+fn compress_zeros_with(cmd: &str, args: &[&str]) -> Option<Vec<u8>> {
+    let mut child = match Command::new(cmd)
+        .args(args)
+        .stdin(Stdio::piped())
+        .stdout(Stdio::piped())
+        .spawn()
+    {
+        Ok(child) => child,
+        Err(_) => {
+            eprintln!("skipping: `{cmd}` CLI not available");
+            return None;
+        }
+    };
+
+    let mut stdin = child.stdin.take().unwrap();
+    let writer = std::thread::spawn(move || {
+        // Well beyond the default 100 MB max_file_size.
+        let zeros = vec![0u8; 200 * 1024 * 1024];
+        stdin.write_all(&zeros)
+    });
+
+    let output = child.wait_with_output().expect("failed to run {cmd}");
+    writer
+        .join()
+        .expect("writer thread panicked")
+        .expect("failed to write to child stdin");
+
+    Some(output.stdout)
+}
+
+fn assert_bomb_rejected(compressed: &[u8], format: ArchiveFormat) {
+    // Sanity: the compressed bomb is much smaller than the decompressed size.
+    assert!(
+        compressed.len() < 10 * 1024 * 1024,
+        "bomb wasn't actually small: {} bytes",
+        compressed.len()
+    );
+
+    let extractor = ArchiveExtractor::new(); // default max_file_size = 100MB
+    let err = extractor.extract(compressed, format).unwrap_err();
+    assert!(matches!(err, ArchiveError::FileTooLarge { .. }), "{err:?}");
+}
+
+// Fastest compression level for each tool: an all-zero input compresses
+// down to next-to-nothing regardless of effort, so there's no need to pay
+// for a high compression ratio here — it just slows the test suite down.
+
+#[test]
+fn xz_decompression_bomb_is_rejected_without_full_buffering() {
+    if let Some(compressed) = compress_zeros_with("xz", &["-0", "-c"]) {
+        assert_bomb_rejected(&compressed, ArchiveFormat::Xz);
+    }
+}
+
+#[test]
+fn gz_decompression_bomb_is_rejected_without_full_buffering() {
+    if let Some(compressed) = compress_zeros_with("gzip", &["-1", "-c"]) {
+        assert_bomb_rejected(&compressed, ArchiveFormat::Gz);
+    }
+}
+
+#[test]
+fn bz2_decompression_bomb_is_rejected_without_full_buffering() {
+    if let Some(compressed) = compress_zeros_with("bzip2", &["-1", "-c"]) {
+        assert_bomb_rejected(&compressed, ArchiveFormat::Bz2);
+    }
+}
+
+#[test]
+fn lz4_decompression_bomb_is_rejected_without_full_buffering() {
+    if let Some(compressed) = compress_zeros_with("lz4", &["-1", "-c"]) {
+        assert_bomb_rejected(&compressed, ArchiveFormat::Lz4);
+    }
+}
+
+#[test]
+fn zst_decompression_bomb_is_rejected_without_full_buffering() {
+    if let Some(compressed) = compress_zeros_with("zstd", &["-1", "-c"]) {
+        assert_bomb_rejected(&compressed, ArchiveFormat::Zst);
+    }
+}

--- a/tests/path_traversal_tests.rs
+++ b/tests/path_traversal_tests.rs
@@ -1,0 +1,148 @@
+//! Tests that crafted, malicious archives are rejected rather than silently
+//! producing entries whose paths (or symlink targets) escape the directory a
+//! caller would extract into.
+
+use archive::{ArchiveError, ArchiveExtractor, ArchiveFormat};
+use std::io::Write;
+use tar::{Builder, EntryType, Header};
+
+fn build_tar_with_header(configure: impl FnOnce(&mut Header)) -> Vec<u8> {
+    let mut builder = Builder::new(Vec::new());
+    let mut header = Header::new_gnu();
+    header.set_size(0);
+    header.set_cksum();
+    configure(&mut header);
+    header.set_cksum();
+    builder.append(&header, std::io::empty()).unwrap();
+    builder.into_inner().unwrap()
+}
+
+#[test]
+fn tar_rejects_parent_dir_traversal_path() {
+    // `Header::set_path` refuses `..` components itself, but a hand-crafted
+    // malicious archive isn't built with this crate's writer - it just has
+    // the raw name bytes on disk. Write the name field directly to simulate
+    // that and confirm the *reader* side still rejects it.
+    let data = build_tar_with_header(|h| {
+        h.set_entry_type(EntryType::Regular);
+        let name_field = &mut h.as_mut_bytes()[0..100];
+        let name = b"../../etc/passwd";
+        name_field[..name.len()].copy_from_slice(name);
+    });
+
+    let err = ArchiveExtractor::new()
+        .extract(&data, ArchiveFormat::Tar)
+        .unwrap_err();
+    assert!(matches!(err, ArchiveError::UnsafePath(_)), "{err:?}");
+}
+
+#[test]
+fn tar_rejects_absolute_path() {
+    let data = build_tar_with_header(|h| {
+        h.set_entry_type(EntryType::Regular);
+        h.set_path_absolute("/etc/passwd").unwrap();
+    });
+
+    let err = ArchiveExtractor::new()
+        .extract(&data, ArchiveFormat::Tar)
+        .unwrap_err();
+    assert!(matches!(err, ArchiveError::UnsafePath(_)), "{err:?}");
+}
+
+#[test]
+fn tar_rejects_symlink_with_traversal_target() {
+    let mut builder = Builder::new(Vec::new());
+    let mut header = Header::new_gnu();
+    header.set_size(0);
+    header.set_entry_type(EntryType::Symlink);
+    header.set_cksum();
+    builder
+        .append_link(&mut header, "innocuous-name", "../../etc/passwd")
+        .unwrap();
+    let data = builder.into_inner().unwrap();
+
+    let err = ArchiveExtractor::new()
+        .extract(&data, ArchiveFormat::Tar)
+        .unwrap_err();
+    assert!(matches!(err, ArchiveError::UnsafePath(_)), "{err:?}");
+}
+
+#[test]
+fn tar_accepts_and_flags_safe_relative_symlink() {
+    let mut builder = Builder::new(Vec::new());
+    let mut header = Header::new_gnu();
+    header.set_size(0);
+    header.set_entry_type(EntryType::Symlink);
+    header.set_cksum();
+    builder
+        .append_link(&mut header, "link.txt", "target.txt")
+        .unwrap();
+    let data = builder.into_inner().unwrap();
+
+    let files = ArchiveExtractor::new()
+        .extract(&data, ArchiveFormat::Tar)
+        .unwrap();
+    assert_eq!(files.len(), 1);
+    assert!(files[0].is_symlink());
+    assert!(!files[0].is_directory());
+    assert!(
+        matches!(&files[0], archive::ArchiveEntry::Symlink { target, .. } if target == "target.txt")
+    );
+}
+
+#[test]
+fn tar_accepts_normal_archive() {
+    let mut builder = Builder::new(Vec::new());
+    let mut header = Header::new_gnu();
+    let content = b"hello world";
+    header.set_size(content.len() as u64);
+    header.set_entry_type(EntryType::Regular);
+    header.set_path("safe/dir/file.txt").unwrap();
+    header.set_cksum();
+    builder.append(&header, &content[..]).unwrap();
+    let data = builder.into_inner().unwrap();
+
+    let files = ArchiveExtractor::new()
+        .extract(&data, ArchiveFormat::Tar)
+        .unwrap();
+    assert_eq!(files.len(), 1);
+    assert_eq!(files[0].path(), "safe/dir/file.txt");
+    assert!(!files[0].is_symlink());
+    assert_eq!(files[0].data(), Some(&content[..]));
+}
+
+#[test]
+fn zip_rejects_parent_dir_traversal_path() {
+    let mut buf = std::io::Cursor::new(Vec::new());
+    {
+        let mut writer = zip::ZipWriter::new(&mut buf);
+        let options: zip::write::FileOptions<'_, ()> = zip::write::FileOptions::default();
+        writer.start_file("../../etc/passwd", options).unwrap();
+        writer.write_all(b"pwned").unwrap();
+        writer.finish().unwrap();
+    }
+
+    let err = ArchiveExtractor::new()
+        .extract(buf.get_ref(), ArchiveFormat::Zip)
+        .unwrap_err();
+    assert!(matches!(err, ArchiveError::UnsafePath(_)), "{err:?}");
+}
+
+#[test]
+fn zip_accepts_normal_archive() {
+    let mut buf = std::io::Cursor::new(Vec::new());
+    {
+        let mut writer = zip::ZipWriter::new(&mut buf);
+        let options: zip::write::FileOptions<'_, ()> = zip::write::FileOptions::default();
+        writer.start_file("safe/file.txt", options).unwrap();
+        writer.write_all(b"hello world").unwrap();
+        writer.finish().unwrap();
+    }
+
+    let files = ArchiveExtractor::new()
+        .extract(buf.get_ref(), ArchiveFormat::Zip)
+        .unwrap();
+    assert_eq!(files.len(), 1);
+    assert_eq!(files[0].path(), "safe/file.txt");
+    assert!(!files[0].is_symlink());
+}

--- a/tests/single_file_tests.rs
+++ b/tests/single_file_tests.rs
@@ -15,7 +15,7 @@ fn test_single_gz_decompression() {
         .expect("Failed to decompress hello.txt.gz");
 
     assert_eq!(files.len(), 1, "Expected single decompressed file");
-    let content = String::from_utf8_lossy(&files[0].data);
+    let content = String::from_utf8_lossy(files[0].data().unwrap());
     assert_eq!(content.trim(), "Hello, World!");
 }
 
@@ -29,7 +29,7 @@ fn test_single_bz2_decompression() {
         .expect("Failed to decompress hello.txt.bz2");
 
     assert_eq!(files.len(), 1, "Expected single decompressed file");
-    let content = String::from_utf8_lossy(&files[0].data);
+    let content = String::from_utf8_lossy(files[0].data().unwrap());
     assert_eq!(content.trim(), "Hello, World!");
 }
 
@@ -43,7 +43,7 @@ fn test_single_xz_decompression() {
         .expect("Failed to decompress hello.txt.xz");
 
     assert_eq!(files.len(), 1, "Expected single decompressed file");
-    let content = String::from_utf8_lossy(&files[0].data);
+    let content = String::from_utf8_lossy(files[0].data().unwrap());
     assert_eq!(content.trim(), "Hello, World!");
 }
 
@@ -57,7 +57,7 @@ fn test_single_lz4_decompression() {
         .expect("Failed to decompress hello.txt.lz4");
 
     assert_eq!(files.len(), 1, "Expected single decompressed file");
-    let content = String::from_utf8_lossy(&files[0].data);
+    let content = String::from_utf8_lossy(files[0].data().unwrap());
     assert_eq!(content.trim(), "Hello, World!");
 }
 
@@ -71,7 +71,7 @@ fn test_single_zst_decompression() {
         .expect("Failed to decompress hello.txt.zst");
 
     assert_eq!(files.len(), 1, "Expected single decompressed file");
-    let content = String::from_utf8_lossy(&files[0].data);
+    let content = String::from_utf8_lossy(files[0].data().unwrap());
     assert_eq!(content.trim(), "Hello, World!");
 }
 
@@ -88,9 +88,9 @@ fn test_gz_extracts_original_filename() {
     // Gzip files created with gzip tool typically store the original filename
     // If no filename in header, should default to "data"
     assert!(
-        files[0].path == "hello.txt" || files[0].path == "data",
+        files[0].path() == "hello.txt" || files[0].path() == "data",
         "Expected 'hello.txt' or 'data', got '{}'",
-        files[0].path
+        files[0].path()
     );
 }
 
@@ -105,7 +105,7 @@ fn test_bz2_uses_data_as_filename() {
 
     assert_eq!(files.len(), 1);
     // bzip2 format doesn't store original filename
-    assert_eq!(files[0].path, "data");
+    assert_eq!(files[0].path(), "data");
 }
 
 #[test]
@@ -119,7 +119,7 @@ fn test_xz_uses_data_as_filename() {
 
     assert_eq!(files.len(), 1);
     // xz format doesn't store original filename
-    assert_eq!(files[0].path, "data");
+    assert_eq!(files[0].path(), "data");
 }
 
 #[test]
@@ -133,7 +133,7 @@ fn test_lz4_uses_data_as_filename() {
 
     assert_eq!(files.len(), 1);
     // lz4 format doesn't store original filename
-    assert_eq!(files[0].path, "data");
+    assert_eq!(files[0].path(), "data");
 }
 
 #[test]
@@ -147,5 +147,5 @@ fn test_zst_uses_data_as_filename() {
 
     assert_eq!(files.len(), 1);
     // zstd format doesn't store original filename
-    assert_eq!(files[0].path, "data");
+    assert_eq!(files[0].path(), "data");
 }

--- a/tests/tar_tests.rs
+++ b/tests/tar_tests.rs
@@ -123,7 +123,7 @@ fn test_nested_tar_gz() {
     // Should contain other archive files
     let nested_files: Vec<_> = files
         .iter()
-        .filter(|f| f.path.ends_with(".zip") || f.path.ends_with(".tar.gz"))
+        .filter(|f| f.path().ends_with(".zip") || f.path().ends_with(".tar.gz"))
         .collect();
 
     assert!(!nested_files.is_empty(), "Expected to find nested archives");
@@ -154,24 +154,24 @@ fn test_all_tar_formats_produce_same_structure() {
     // All should contain the same files
     for file in &files_tar {
         assert!(
-            files_tar_gz.iter().any(|f| f.path == file.path),
+            files_tar_gz.iter().any(|f| f.path() == file.path()),
             "tar.gz missing file: {}",
-            file.path
+            file.path()
         );
         assert!(
-            files_tar_bz2.iter().any(|f| f.path == file.path),
+            files_tar_bz2.iter().any(|f| f.path() == file.path()),
             "tar.bz2 missing file: {}",
-            file.path
+            file.path()
         );
         assert!(
-            files_tar_xz.iter().any(|f| f.path == file.path),
+            files_tar_xz.iter().any(|f| f.path() == file.path()),
             "tar.xz missing file: {}",
-            file.path
+            file.path()
         );
         assert!(
-            files_tar_zst.iter().any(|f| f.path == file.path),
+            files_tar_zst.iter().any(|f| f.path() == file.path()),
             "tar.zst missing file: {}",
-            file.path
+            file.path()
         );
     }
 }

--- a/tests/zip_tests.rs
+++ b/tests/zip_tests.rs
@@ -78,7 +78,7 @@ fn test_nested_zip() {
     // Should contain other archive files
     let nested_files: Vec<_> = files
         .iter()
-        .filter(|f| f.path.ends_with(".zip") || f.path.ends_with(".tar.gz"))
+        .filter(|f| f.path().ends_with(".zip") || f.path().ends_with(".tar.gz"))
         .collect();
 
     assert!(!nested_files.is_empty(), "Expected to find nested archives");
@@ -97,17 +97,17 @@ fn test_deeply_nested_zip() {
 
     // First level extraction
     let level1_file = assert_contains_file(&files, "level1.txt");
-    assert!(!level1_file.data.is_empty());
+    assert!(!level1_file.data().unwrap().is_empty());
 
     // Should contain level2.zip
     let level2_zip = files
         .iter()
-        .find(|f| f.path.contains("level2.zip"))
+        .find(|f| f.path().contains("level2.zip"))
         .expect("Expected to find level2.zip");
 
     // Extract level 2
     let level2_files = extractor
-        .extract(&level2_zip.data, ArchiveFormat::Zip)
+        .extract(level2_zip.data().unwrap(), ArchiveFormat::Zip)
         .expect("Failed to extract level2.zip");
 
     assert_contains_file(&level2_files, "level2.txt");
@@ -135,7 +135,7 @@ fn test_empty_dirs_zip() {
         .expect("Failed to extract empty-dirs.zip");
 
     // Should contain directory entries
-    let dirs: Vec<_> = files.iter().filter(|f| f.is_directory).collect();
+    let dirs: Vec<_> = files.iter().filter(|f| f.is_directory()).collect();
     assert!(!dirs.is_empty(), "Expected to find directories");
 }
 
@@ -151,8 +151,8 @@ fn test_special_chars_zip() {
     assert!(!files.is_empty(), "Expected non-empty archive");
 
     // Check for files with special characters
-    let has_spaces = files.iter().any(|f| f.path.contains("file with spaces"));
-    let has_umlaut = files.iter().any(|f| f.path.contains("ümlaut"));
+    let has_spaces = files.iter().any(|f| f.path().contains("file with spaces"));
+    let has_umlaut = files.iter().any(|f| f.path().contains("ümlaut"));
 
     assert!(
         has_spaces || has_umlaut,


### PR DESCRIPTION
## Path and symlink traversal safety

Fixes path and directory traversal vulnerabilities that could occur if users blindly trust paths given back by this crate by directly writing them to disk.

- Added `validate_path` to reject 'unsafe' paths within archives that could write outside the extraction point root dir if the crate user doesn't canonicalize/validate the paths returned from this crate themselves before writing to disk.
- Any archive that fails path safety gets a new `Err::UnsafePath(String)` Err variant so they know what path attempted to bypass and can handle it themselves.
- I kinda assumed that any archive that tries to perform a traversal attack doesn't have a legitimate purpose for existing, so you can't get ArchiveEntries for archives that attempt to do so without using a different crate.

## Major API changes

- I changed `ExtractedFile` into `ArchiveEntry`, an enum with variants that represent `File`, `Directory`, and `Symlink`. This is a better approach for a Rust crate since it means users have to pattern match against variants instead of using bools stored in struct fields. Allocating an empty Vec for directories was a bad design choice compared to just using enums. This has convenience methods for path/is_file/directory/data/etc.

## Hardening against extraction bombs

- Fixed blind trust of archive metadata declared size. Before this change, `extract_zip`, `process_tar_entries`, `extract_7z`, and `process_ar_entries` trusted archive entries' declared size without any checks. Malicious archives could be decompressed in memory exceeding `max_total_size` before being flagged by this crate.
- Fixed single file decompression (.gz/.bz2/.xz/.lz4/.zst) and .tar.xz) from loading their entire contents into memory before the crate checks if the configured `max_total_size/max_file_size` was exceeded.
- My fix adds a `BoundedWriter` that prevents an archive that declares incorrect metadata and actually exceeds `max_total_size` from allocating an unbounded amount of memory.
- Uses `Vec::try_reserve_exact` to check whether allocating the expected size would exceed system/process resources, so that we can expose an explicit `Err::AllocationFailed` instead of aborting/getting OOM killed.

Closes #19
